### PR TITLE
feat: support Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,12 @@
   "require": {
     "php": ">=8.2",
     "doctrine/orm": "^3",
-    "symfony/doctrine-bridge": "^7.0",
-    "symfony/serializer": "^7.0",
-    "symfony/validator": "^7.0",
-    "symfony/property-access": "^7.0",
-    "symfony/framework-bundle": "^7.0",
-    "symfony/uid": "^7.0"
+    "symfony/doctrine-bridge": "^7.0 || ^8.0",
+    "symfony/serializer": "^7.0 || ^8.0",
+    "symfony/validator": "^7.0 || ^8.0",
+    "symfony/property-access": "^7.0 || ^8.0",
+    "symfony/framework-bundle": "^7.0 || ^8.0",
+    "symfony/uid": "^7.0 || ^8.0"
   },
   "license": "mit",
   "authors": [


### PR DESCRIPTION
Widen the Symfony component constraints to `^7.0 || ^8.0` so `barlito/utils` installs on Symfony 8 (stays compatible with Symfony 7). Needed to upgrade downstream projects (e.g. dog-help-scheduler) to Symfony 8.1.

Released as **v1.7.0** (additive, backward-compatible).