### PR TITLE
fix(traits): type the id properties Uuid/Ulid to stop phantom changesets

### DIFF
--- a/src/Traits/IdUlidTrait.php
+++ b/src/Traits/IdUlidTrait.php
@@ -8,26 +8,34 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\IdGenerator\UlidGenerator;
 use Symfony\Bridge\Doctrine\Types\UlidType;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Uid\Ulid;
 use Symfony\Component\Validator\Constraints as Assert;
 
 trait IdUlidTrait
 {
+    /**
+     * Typed Ulid on purpose: with a `?string` property against the UlidType
+     * column, Doctrine keeps the ORIGINAL value as a Ulid object while the
+     * property holds a string — the changeset then flags `id` as changed on
+     * EVERY hydrated entity, and any flush() rewrites every loaded row
+     * (`UPDATE ... SET id = <same>, updated_at = <now>`).
+     */
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\Column(name: 'id', type: UlidType::NAME, unique: true)]
     #[ORM\CustomIdGenerator(class: UlidGenerator::class)]
     #[Assert\Ulid]
     #[Groups(['default'])]
-    private ?string $id = null;
+    private ?Ulid $id = null;
 
     public function getId(): ?string
     {
-        return $this->id;
+        return $this->id?->toBase32();
     }
 
     public function setId(string $id): self
     {
-        $this->id = $id;
+        $this->id = Ulid::fromString($id);
 
         return $this;
     }

--- a/src/Traits/IdUuidTrait.php
+++ b/src/Traits/IdUuidTrait.php
@@ -8,26 +8,34 @@ use Doctrine\ORM\Mapping as ORM;
 use Symfony\Bridge\Doctrine\IdGenerator\UuidGenerator;
 use Symfony\Bridge\Doctrine\Types\UuidType;
 use Symfony\Component\Serializer\Annotation\Groups;
+use Symfony\Component\Uid\Uuid;
 use Symfony\Component\Validator\Constraints as Assert;
 
 trait IdUuidTrait
 {
+    /**
+     * Typed Uuid on purpose: with a `?string` property against the UuidType
+     * column, Doctrine keeps the ORIGINAL value as a Uuid object while the
+     * property holds a string — the changeset then flags `id` as changed on
+     * EVERY hydrated entity, and any flush() rewrites every loaded row
+     * (`UPDATE ... SET id = <same>, updated_at = <now>`).
+     */
     #[ORM\Id]
     #[ORM\GeneratedValue(strategy: 'CUSTOM')]
     #[ORM\Column(name: 'id', type: UuidType::NAME, unique: true)]
     #[ORM\CustomIdGenerator(class: UuidGenerator::class)]
     #[Assert\Uuid]
     #[Groups(['default'])]
-    private ?string $id = null;
+    private ?Uuid $id = null;
 
     public function getId(): ?string
     {
-        return $this->id;
+        return $this->id?->toRfc4122();
     }
 
     public function setId(string $id): self
     {
-        $this->id = $id;
+        $this->id = Uuid::fromString($id);
 
         return $this;
     }


### PR DESCRIPTION
## Le bug

Les traits `IdUuidTrait` / `IdUlidTrait` typent `$id` en `?string` alors que la colonne est `UuidType`/`UlidType`. À l'hydratation, Doctrine conserve la valeur ORIGINALE en objet `Uuid`/`Ulid` tandis que la propriété contient une string → le changeset de l'UnitOfWork considère `id` **modifié sur chaque entité chargée**, et n'importe quel `flush()` réécrit toutes les lignes hydratées :

```sql
UPDATE card SET id = '<même valeur>', updated_at = '<now>' WHERE id = '<même valeur>'
```

Effets : requêtes multipliées silencieusement (constaté dans youl-tcg : **18 UPDATE fantômes par ouverture de booster**, 44 → 24 requêtes après fix) et **updated_at corrompu** (Timestampable se déclenche sur ces faux updates).

## Le fix

Propriétés typées `?Uuid` / `?Ulid` : la propriété et l'original du changeset sont le même objet → changeset propre.

- `getId()` rend toujours `?string` (rfc4122 / base32) : **aucun appelant impacté**
- `setId(string)` accepte la même string et convertit

## Vérification (youl-tcg)

```php
$card = $em->getRepository(Card::class)->findOneBy([]);
$uow->computeChangeSets();
// avant : changeset = ["id"] (UuidV7 -> string)
// après : changeset = []
```

Suite complète de youl-tcg verte avec un trait local identique à ce patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)